### PR TITLE
modified flowControl showImmediately

### DIFF
--- a/mod/flowControl.js
+++ b/mod/flowControl.js
@@ -322,7 +322,7 @@
                         // check if showInitialView contains a registered module
                         for (i = 0; i < l; i++) {
                             if (showInitialView.indexOf(modNames[i]) !== -1) {
-                                showInitialView.push(function transmitParameters() {
+                                showInitialView.push(function () {
                                     onShowInitialViewComplete.forEach(function(fc) {
                                         fc();
                                     });


### PR DESCRIPTION
modified flowControl showImmediately to only invoke show-function once on given views (after hiding all other views)

added feature to flowControl: 
posting additional url-parameters to application on canny.ready via window.postMessage (can provide some extra information when deeplinking into a single page application)