### PR TITLE
add crossorigin to script element

### DIFF
--- a/mod/async.js
+++ b/mod/async.js
@@ -1,3 +1,8 @@
+/*
+ *  Copyright (c) 2003-2019 GameDuell GmbH, All Rights Reserved
+ *  This document is strictly confidential and sole property of GameDuell GmbH, Berlin, Germany
+ */
+
 /*global canny */
 /*jslint browser: true*/
 
@@ -49,6 +54,7 @@
             }
             node.type = "text/javascript";
             node.async = true;
+            node.setAttribute('crossorigin', 'anonymous');
             node.setAttribute('src', src);
             node.addEventListener('load', cb, false);
             node.addEventListener('error', cb, true);

--- a/mod/async.js
+++ b/mod/async.js
@@ -1,8 +1,3 @@
-/*
- *  Copyright (c) 2003-2019 GameDuell GmbH, All Rights Reserved
- *  This document is strictly confidential and sole property of GameDuell GmbH, Berlin, Germany
- */
-
 /*global canny */
 /*jslint browser: true*/
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "auth": "eightyfour",
   "email": "eightyfour@thinkuseful.de",
   "description": "Simple dom module manager with basic view support.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "browserify": "canny.js",
   "engines": {
     "node": ">= v0.10.0"


### PR DESCRIPTION
When loading pages and scripts via canny.async.loadHTML and these scripts will throw some JS error, the original caller is not able to get the error details due to CORS issues. 
See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes